### PR TITLE
Add a link to the job detail in the notification e-mail.

### DIFF
--- a/job_manager/nmpi-job-manager-app/nmpi/queue/controllers.js
+++ b/job_manager/nmpi-job-manager-app/nmpi/queue/controllers.js
@@ -295,6 +295,7 @@ angular.module('nmpi')
         Context.get({ctx: $rootScope.ctx}, function(context){
             //console.log("create collab id: "+context.collab.id);
             $scope.job.collab_id = context.collab.id;
+            $scope.job.provenance = {'collaboratory': {'nav_item': context.id}}
         });
         UiStorageGetData.job = $scope.job;
 
@@ -464,6 +465,7 @@ angular.module('nmpi')
             Context.get({ctx: $rootScope.ctx}, function(context){
                 //console.log("create collab id: "+context.collab.id);
                 $scope.job.collab_id = context.collab.id;
+                $scope.job.provenance = {'collaboratory': {'nav_item': context.id}}
             });
         });
 

--- a/simqueue/api/resources.py
+++ b/simqueue/api/resources.py
@@ -346,7 +346,7 @@ class QueueResource(BaseJobResource):
             if len(users) > 1:
                 logger.warning("Multiple users found with the same oidc id.")
             if email:
-                logger.info("Sending e-mail about job #{} to {}".format(str(bundle.data['id']), bundle.request.user.email))
+                logger.info("Sending e-mail about job #{} to {}".format(str(bundle.data['id']), email))
                 log_list = Log.objects.filter(pk=bundle.data['id'])
                 if log_list.count() == 0:
                     log_content = ""
@@ -362,7 +362,11 @@ class QueueResource(BaseJobResource):
                 subject = '[HBP Neuromorphic] job ' + str(bundle.data['id']) + ' ' + bundle.data['status']
                 content = 'HBP Neuromorphic Computing Platform: Job {} {}\n\n'.format(bundle.data['id'],
                                                                                       bundle.data['status'])
-                content += "https://collab.humanbrainproject.eu/#/collab/{}\n\n".format(bundle.data['collab_id'])
+                target_url = "https://collab.humanbrainproject.eu/#/collab/{}".format(bundle.data['collab_id'])
+                if bundle.data['provenance'] and 'collaboratory' in bundle.data['provenance']:
+                    target_url += "/nav/{}?state=job.{}".format(bundle.data['provenance']['collaboratory'].get('nav_item', 'unknown'),
+                                                                bundle.data['id'])
+                content += target_url + "\n\n"
                 content += log_content
                 try:
                     send_mail(


### PR DESCRIPTION
This is a bit hacky, since it uses the provenance field to pass the nav item id, but I can't see another way to do it, short of adding a new database field, since the e-mail is sent on job completion, by which time we no longer have a valid user token, in general, so can't query the Collaboratory service.